### PR TITLE
Updated Submission Related Stuff

### DIFF
--- a/src/Assessment-Management-System/Views/Submissions/Create.cshtml
+++ b/src/Assessment-Management-System/Views/Submissions/Create.cshtml
@@ -15,6 +15,7 @@
             <label asp-for="AssessmentID" class="col-md-2 control-label"></label>
             <div class="col-md-10">
                 <select asp-for="AssessmentID" class="form-control" asp-items="ViewBag.AssessmentID"></select>
+                <!--<select asp-for="Assessment" class="form-control" asp-items="Model.Assessment"></select>-->
             </div>
         </div>
         <div class="form-group">

--- a/src/Assessment-Management-System/Views/Submissions/Details.cshtml
+++ b/src/Assessment-Management-System/Views/Submissions/Details.cshtml
@@ -1,4 +1,5 @@
 @model Assessment_Management_System.Models.Submission
+@inject UserManager<ApplicationUser> UserManager
 
 @{
     ViewData["Title"] = "Details";
@@ -32,6 +33,14 @@
     </dl>
 </div>
 <div>
-    <a asp-action="Edit" asp-route-id="@Model.ID">Edit</a> |
+    @if (await AuthorizationService.AuthorizeAsync(User, "student"))
+    {
+        if (UserManager.GetUserId(User) == Model.studentID)
+        {
+            <a asp-action="Edit" asp-route-id="@Model.ID">Edit</a>
+            @: |
+        }
+
+    }
     <a asp-action="Index">Back to List</a>
 </div>

--- a/src/Assessment-Management-System/Views/Submissions/Edit.cshtml
+++ b/src/Assessment-Management-System/Views/Submissions/Edit.cshtml
@@ -14,19 +14,28 @@
         <input type="hidden" asp-for="ID" />
         <input type="hidden" asp-for="storageFileName" />
         <input type="hidden" asp-for="studentID" />
+        <input type="hidden" asp-for="AssessmentID" />
+        <input type="hidden" asp-for="fileName" />
+
         <div class="form-group">
-            <label asp-for="AssessmentID" class="col-md-2 control-label"></label>
+            <label asp-for="Assessment" class="col-md-2 control-label"></label>
             <div class="col-md-10">
-                <select asp-for="AssessmentID" class="form-control" asp-items="ViewBag.AssessmentID"></select>
+                <!--<select asp-for="AssessmentID" class="form-control" asp-items="ViewBag.AssessmentID"></select>-->
+                @Model.Assessment.Title
             </div>
         </div>
+
+        <h4>Previous Submission</h4>
         <div class="form-group">
             <label asp-for="fileName" class="col-md-2 control-label"></label>
             <div class="col-md-10">
-                <input asp-for="fileName" class="form-control" />
+                <!--<input asp-for="fileName" class="form-control" />-->
+                @Model.fileName
                 <span asp-validation-for="fileName" class="text-danger" />
             </div>
         </div>
+
+        <h4>New Submission</h4>
         <div class="form-group">
             <label name="file" class="col-md-2 control-label">New File</label>
             <div class="col-md-10">

--- a/src/Assessment-Management-System/Views/Submissions/Index.cshtml
+++ b/src/Assessment-Management-System/Views/Submissions/Index.cshtml
@@ -1,4 +1,5 @@
 @model IEnumerable<Assessment_Management_System.Models.Submission>
+@inject UserManager<ApplicationUser> UserManager
 
 @{
     ViewData["Title"] = "Index";
@@ -21,6 +22,9 @@
             <th>
                 @Html.DisplayNameFor(model => model.submittedOn)
             </th>
+            <th>
+                @Html.DisplayNameFor(model => model.ApplicationUser.UserName)
+            </th>
             <th></th>
         </tr>
     </thead>
@@ -37,9 +41,29 @@
                 @Html.DisplayFor(modelItem => item.submittedOn)
             </td>
             <td>
-                <a asp-action="Edit" asp-route-id="@item.ID">Edit</a> |
-                <a asp-action="Details" asp-route-id="@item.ID">Details</a> |
-                <a asp-action="Delete" asp-route-id="@item.ID">Delete</a>
+                @Html.DisplayFor(modelItem => item.ApplicationUser.UserName)
+            </td>
+            <td>
+                <a asp-action="Details" asp-route-id="@item.ID">Details</a>
+
+                @if (await AuthorizationService.AuthorizeAsync(User, "student"))
+                {
+                    @: |
+                    <a asp-action="Edit" asp-route-id="@item.ID">Edit</a>
+                    @: |
+                    <a asp-action="Delete" asp-route-id="@item.ID">Delete</a>
+                }
+
+                @if (await AuthorizationService.AuthorizeAsync(User, "teacher"))
+                {
+                    if (UserManager.GetUserId(User) == item.Assessment.teacherID)
+                    {
+                        @: |
+                        <a asp-action="Download" asp-route-id="@item.ID">Download File</a>
+                    }
+
+                }
+
             </td>
         </tr>
 }


### PR DESCRIPTION
Did a number of updates to the Submission part of the site.
1. The list of the Index page only shows submissions for that student.
2. Teachers can download individual student files only for their
assessments.
3. Separated the submission edit page to show previous submittion and
new submission sections.
4. Updated the Edit page so the assessment isn't a list anymore. It is
just the assessment name.
5. Misc other things with links and when they show up.
